### PR TITLE
Make the colors array optional

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -51,7 +51,7 @@ impl fmt::Display for ConfigError {
 pub struct Config {
     pub one_way: Option<bool>,
     pub fail_command: Option<String>,
-    pub colors: Colors,
+    pub colors: Option<Colors>,
 }
 
 #[derive(Deserialize)]

--- a/src/options.rs
+++ b/src/options.rs
@@ -104,9 +104,11 @@ impl Options {
             Ok(config) => {
                 one_way = one_way.or(config.one_way);
                 fail_command = fail_command.or_else(|| config.fail_command.clone());
-                init_color = init_color.or_else(|| config.colors.init_color.map(Color::from));
-                input_color = input_color.or_else(|| config.colors.input_color.map(Color::from));
-                fail_color = fail_color.or_else(|| config.colors.fail_color.map(Color::from));
+                if let Some(colors) = &config.colors {
+                    init_color = init_color.or_else(|| colors.init_color.map(Color::from));
+                    input_color = input_color.or_else(|| colors.input_color.map(Color::from));
+                    fail_color = fail_color.or_else(|| colors.fail_color.map(Color::from));
+                }
             }
             Err(ConfigError::NotFound) => {}
             Err(err) => log::error!("{}", err),

--- a/waylock.toml
+++ b/waylock.toml
@@ -1,5 +1,7 @@
 # waylock.toml
 
+# Note: all fields are optional. If omitted a default value will be used.
+
 # If set to true, never revert the color after input or failure.
 one_way = false
 


### PR DESCRIPTION
An empty array was previously required to avoid a parse error.